### PR TITLE
Coverted from codegangsta to urfave

### DIFF
--- a/paranoid-cli/commands/automountcmd.go
+++ b/paranoid-cli/commands/automountcmd.go
@@ -2,7 +2,7 @@ package commands
 
 import (
 	"fmt"
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 	"io/ioutil"
 	"os"
 	"os/user"

--- a/paranoid-cli/commands/buildfscmd.go
+++ b/paranoid-cli/commands/buildfscmd.go
@@ -3,7 +3,7 @@ package commands
 import (
 	"fmt"
 	progress "github.com/cheggaaa/pb"
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 	"github.com/pp2p/paranoid/libpfs/returncodes"
 	pb "github.com/pp2p/paranoid/proto/raft"
 	"github.com/pp2p/paranoid/raft"

--- a/paranoid-cli/commands/deletecmd.go
+++ b/paranoid-cli/commands/deletecmd.go
@@ -2,7 +2,7 @@ package commands
 
 import (
 	"fmt"
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 	"os"
 	"os/user"
 	"path"

--- a/paranoid-cli/commands/historycmd.go
+++ b/paranoid-cli/commands/historycmd.go
@@ -2,7 +2,7 @@ package commands
 
 import (
 	"fmt"
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 	pb "github.com/pp2p/paranoid/proto/raft"
 	"github.com/pp2p/paranoid/raft"
 	"io/ioutil"

--- a/paranoid-cli/commands/initcmd.go
+++ b/paranoid-cli/commands/initcmd.go
@@ -3,7 +3,7 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 	"github.com/pp2p/paranoid/libpfs/commands"
 	"github.com/pp2p/paranoid/libpfs/returncodes"
 	"github.com/pp2p/paranoid/paranoid-cli/tls"

--- a/paranoid-cli/commands/listServecmd.go
+++ b/paranoid-cli/commands/listServecmd.go
@@ -2,7 +2,7 @@ package commands
 
 import (
 	"fmt"
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 	pb "github.com/pp2p/paranoid/proto/fileserver"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"

--- a/paranoid-cli/commands/listcmd.go
+++ b/paranoid-cli/commands/listcmd.go
@@ -2,7 +2,7 @@ package commands
 
 import (
 	"fmt"
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 	"io/ioutil"
 	"os/user"
 	"path"

--- a/paranoid-cli/commands/listnodescmd.go
+++ b/paranoid-cli/commands/listnodescmd.go
@@ -2,7 +2,7 @@ package commands
 
 import (
 	"fmt"
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 	"github.com/pp2p/paranoid/pfsd/intercom"
 	"github.com/pp2p/paranoid/raft"
 	"io/ioutil"

--- a/paranoid-cli/commands/mountcmd.go
+++ b/paranoid-cli/commands/mountcmd.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 	"github.com/pp2p/paranoid/libpfs/commands"
 	"github.com/pp2p/paranoid/libpfs/returncodes"
 	"github.com/pp2p/paranoid/pfsd/intercom"

--- a/paranoid-cli/commands/restartcmd.go
+++ b/paranoid-cli/commands/restartcmd.go
@@ -2,7 +2,7 @@ package commands
 
 import (
 	"fmt"
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 	"io/ioutil"
 	"os"
 	"os/user"

--- a/paranoid-cli/commands/securecmd.go
+++ b/paranoid-cli/commands/securecmd.go
@@ -2,7 +2,7 @@ package commands
 
 import (
 	"fmt"
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 	"github.com/pp2p/paranoid/paranoid-cli/tls"
 	"os"
 	"os/user"

--- a/paranoid-cli/commands/servecmd.go
+++ b/paranoid-cli/commands/servecmd.go
@@ -2,7 +2,7 @@ package commands
 
 import (
 	"fmt"
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 	pb "github.com/pp2p/paranoid/proto/fileserver"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"

--- a/paranoid-cli/commands/statuscmd.go
+++ b/paranoid-cli/commands/statuscmd.go
@@ -2,7 +2,7 @@ package commands
 
 import (
 	"fmt"
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 	"github.com/pp2p/paranoid/pfsd/intercom"
 	"io/ioutil"
 	"net/rpc"

--- a/paranoid-cli/commands/unmountcmd.go
+++ b/paranoid-cli/commands/unmountcmd.go
@@ -2,7 +2,7 @@ package commands
 
 import (
 	"fmt"
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 	"io/ioutil"
 	"os"
 	"os/user"

--- a/paranoid-cli/commands/unservecmd.go
+++ b/paranoid-cli/commands/unservecmd.go
@@ -2,7 +2,7 @@ package commands
 
 import (
 	"fmt"
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 	pb "github.com/pp2p/paranoid/proto/fileserver"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"

--- a/paranoid-cli/main.go
+++ b/paranoid-cli/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 	pfscommands "github.com/pp2p/paranoid/libpfs/commands"
 	"github.com/pp2p/paranoid/logger"
 	"github.com/pp2p/paranoid/paranoid-cli/commands"


### PR DESCRIPTION
The repository moved. This fixes one of the problems of `go get`ting as defined in #14.

Generated by
`find . -type f -exec sed -i 's/github.com\/codegangsta/github.com\/urfave/g' {} \;`