### PR TITLE
Fixed spelling mistakes reported by goreportcard

### DIFF
--- a/discovery-server/dnetserver/discovery_test.go
+++ b/discovery-server/dnetserver/discovery_test.go
@@ -213,7 +213,7 @@ func TestDiscoveryPasswords(t *testing.T) {
 	}
 	_, err = discovery.Join(nil, &joinRequest)
 	if err == nil {
-		t.Error("Node2 sucessfully joined password protected pool without password")
+		t.Error("Node2 successfully joined password protected pool without password")
 	}
 
 	//Join node3 with incorrect password
@@ -224,7 +224,7 @@ func TestDiscoveryPasswords(t *testing.T) {
 	}
 	_, err = discovery.Join(nil, &joinRequest)
 	if err == nil {
-		t.Error("Node3 sucessfully joined password protected pool with incorrect password")
+		t.Error("Node3 successfully joined password protected pool with incorrect password")
 	}
 
 	//Join node4 with correct password

--- a/discovery-server/dnetserver/state.go
+++ b/discovery-server/dnetserver/state.go
@@ -32,7 +32,7 @@ func LoadState() {
 	_, err := os.Stat(StateDirectoryPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			Log.Info("Tried loading state from state directory but it's non-existant")
+			Log.Info("Tried loading state from state directory but it's non-existent")
 			return
 		} else {
 			Log.Fatal("Couldn't stat state directory:", err)

--- a/libpfs/commands/util.go
+++ b/libpfs/commands/util.go
@@ -249,7 +249,7 @@ func getFileType(directory, filePath string) (returncodes.Code, error) {
 
 	f, err = os.Lstat(path.Join(directory, "contents", string(inode)))
 	if err != nil {
-		return 0, fmt.Errorf("error getting file type of %s, symlink check error occured: %s", filePath, err)
+		return 0, fmt.Errorf("error getting file type of %s, symlink check error occurred: %s", filePath, err)
 	}
 
 	if f.Mode()&os.ModeSymlink > 0 {

--- a/paranoid-cli/commands/servecmd.go
+++ b/paranoid-cli/commands/servecmd.go
@@ -2,8 +2,8 @@ package commands
 
 import (
 	"fmt"
-	"github.com/urfave/cli"
 	pb "github.com/pp2p/paranoid/proto/fileserver"
+	"github.com/urfave/cli"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"io/ioutil"
@@ -59,5 +59,5 @@ func Serve(c *cli.Context) {
 		fmt.Println("Unable to send File to Discovery Share Server")
 		Log.Fatal("Couldn't message Discovery Share Server", err)
 	}
-	fmt.Println("File now avaliable at:", "http://"+ip+response.ServerPort+"/"+response.ServeResponse)
+	fmt.Println("File now available at:", "http://"+ip+response.ServerPort+"/"+response.ServeResponse)
 }

--- a/paranoid-cli/main.go
+++ b/paranoid-cli/main.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/urfave/cli"
 	pfscommands "github.com/pp2p/paranoid/libpfs/commands"
 	"github.com/pp2p/paranoid/logger"
 	"github.com/pp2p/paranoid/paranoid-cli/commands"
 	"github.com/pp2p/paranoid/paranoid-cli/tls"
+	"github.com/urfave/cli"
 	"os"
 	"os/user"
 	"path"
@@ -154,7 +154,7 @@ func main() {
 				},
 				cli.IntFlag{
 					Name:  "a, access",
-					Usage: "give an acces ammount",
+					Usage: "give an access amount",
 				},
 			},
 		},

--- a/pfsd/main.go
+++ b/pfsd/main.go
@@ -124,14 +124,14 @@ func startRPCServer(lis *net.Listener, password string) {
 		for {
 			select {
 			case <-timeout:
-				log.Fatal("Unable to create inital generation")
+				log.Fatal("Unable to create initial generation")
 			default:
 				_, _, err := globals.RaftNetworkServer.RequestNewGeneration(globals.ThisNode.UUID)
 				if err == nil {
-					log.Info("Successfuly created inital generation")
+					log.Info("Successfully created initial generation")
 					break initalGenerationLoop
 				}
-				log.Error("Unable to create inital generation:", err)
+				log.Error("Unable to create initial generation:", err)
 			}
 		}
 		if globals.Encrypted {
@@ -224,7 +224,7 @@ func startRPCServer(lis *net.Listener, password string) {
 						}
 						sendKeysTimer.Reset(JoinSendKeysInterval)
 					case keySendInfo := <-sendKeysResponse:
-						log.Info("Recieved key piece response")
+						log.Info("Received key piece response")
 						if keySendInfo.err != nil {
 							if keySendInfo.err == keyman.ErrGenerationDeprecated {
 								log.Error("Attempting to replicate keys for deprecated generation")
@@ -250,7 +250,7 @@ func startRPCServer(lis *net.Listener, password string) {
 						if err != nil {
 							log.Error("Unable to join a raft cluster:", err)
 						} else {
-							log.Info("Sucessfully joined raft cluster")
+							log.Info("Successfully joined raft cluster")
 							globals.Wait.Add(1)
 							go func() {
 								defer globals.Wait.Done()

--- a/pfsd/pfi/main.go
+++ b/pfsd/pfi/main.go
@@ -53,7 +53,7 @@ func StartPfi(logVerbose bool) {
 				if err != nil {
 					Log.Fatal("Error unmounting : ", err)
 				}
-				Log.Info("pfi unmounted sucessfully")
+				Log.Info("pfi unmounted successfully")
 				return
 			}
 		}

--- a/pfsd/pfi/pfi_integration_test.go
+++ b/pfsd/pfi/pfi_integration_test.go
@@ -3,11 +3,11 @@
 package pfi
 
 import (
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/pathfs"
 	"github.com/pp2p/paranoid/libpfs/commands"
 	"github.com/pp2p/paranoid/logger"
 	"github.com/pp2p/paranoid/pfsd/globals"
-	"github.com/hanwen/go-fuse/fuse"
-	"github.com/hanwen/go-fuse/fuse/pathfs"
 	"os"
 	"path"
 	"testing"
@@ -60,7 +60,7 @@ func TestFuseFilePerms(t *testing.T) {
 		t.Error("Error calling GetAttr")
 	}
 	if os.FileMode(attr.Mode).Perm() != 0777 {
-		t.Error("Recieved incorrect permisions", os.FileMode(attr.Mode))
+		t.Error("Received incorrect permissions", os.FileMode(attr.Mode))
 	}
 
 	canAccess := pfs.Access("helloworld.txt", 4, nil)
@@ -152,7 +152,7 @@ func TestFuseFileSystemOperations(t *testing.T) {
 		t.Error("Incorrect number of files in directory : ", dirEntries)
 	}
 	if dirEntries[0].Name != "file1" {
-		t.Error("Incorrect file name recieved : ", dirEntries[0].Name)
+		t.Error("Incorrect file name received : ", dirEntries[0].Name)
 	}
 
 	code = pfs.Rename("file1", "file2", nil)
@@ -168,7 +168,7 @@ func TestFuseFileSystemOperations(t *testing.T) {
 		t.Error("Incorrect number of files in directory : ", len(dirEntries))
 	}
 	if dirEntries[0].Name != "file2" {
-		t.Error("Incorrect file name recieved : ", dirEntries[0].Name)
+		t.Error("Incorrect file name received : ", dirEntries[0].Name)
 	}
 
 	code = pfs.Unlink("file2", nil)
@@ -258,6 +258,6 @@ func TestFuseUtimes(t *testing.T) {
 		t.Error("Incorrect mtime received : ", attr.ModTime().Round(roundFactor))
 	}
 	if attr.AccessTime().Round(roundFactor) != atime.Round(roundFactor) {
-		t.Error("Incorrect atime recieved : ", attr.AccessTime().Round(roundFactor))
+		t.Error("Incorrect atime received : ", attr.AccessTime().Round(roundFactor))
 	}
 }

--- a/pfsd/pnetclient/key_distribution.go
+++ b/pfsd/pnetclient/key_distribution.go
@@ -34,7 +34,7 @@ func Distribute(key *keyman.Key, peers []globals.Node, generation int) error {
 		if err != nil {
 			Log.Error("Error marking generation complete:", err)
 		} else {
-			Log.Info("Succesfully completed generation", generation)
+			Log.Info("Successfully completed generation", generation)
 		}
 	}
 	return nil

--- a/pfsd/pnetserver/joincluster.go
+++ b/pfsd/pnetserver/joincluster.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-//JoinCluster recieves requests from nodes asking to join raft cluster
+//JoinCluster receives requests from nodes asking to join raft cluster
 func (s *ParanoidServer) JoinCluster(ctx context.Context, req *pb.JoinClusterRequest) (*pb.EmptyMessage, error) {
 	if req.PoolPassword == "" {
 		if len(globals.PoolPasswordHash) != 0 {

--- a/pfsd/pnetserver/newgeneration.go
+++ b/pfsd/pnetserver/newgeneration.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
-// NewGeneration recieves requests from nodes asking to create a new KeyPiece
+// NewGeneration receives requests from nodes asking to create a new KeyPiece
 // generation in preparation for joining the cluster.
 func (s *ParanoidServer) NewGeneration(ctx context.Context, req *pb.NewGenerationRequest) (*pb.NewGenerationResponse, error) {
 	if req.PoolPassword == "" {

--- a/raft/configuration.go
+++ b/raft/configuration.go
@@ -105,7 +105,7 @@ func (c *Configuration) NewFutureConfiguration(nodes []Node, lastLogIndex uint64
 	}
 }
 
-//UpdateCurrentConfiguration updates the current configuraiton given a set of nodes.
+//UpdateCurrentConfiguration updates the current configuration given a set of nodes.
 //If all the nodes are in the future configuration, the future configuration is changed to the current configuration.
 func (c *Configuration) UpdateCurrentConfiguration(nodes []Node, lastLogIndex uint64) {
 	c.configLock.Lock()

--- a/raft/demo/demo.go
+++ b/raft/demo/demo.go
@@ -79,7 +79,7 @@ func manageNode(raftServer *raft.RaftNetworkServer) {
 				Demo: &pb.DemoCommand{uint64(randomNumber)},
 			})
 			if err == nil {
-				log.Println(raftServer.State.NodeId, "successfullly added", randomNumber, "to the log")
+				log.Println(raftServer.State.NodeId, "successfully added", randomNumber, "to the log")
 			} else {
 				log.Println(raftServer.State.NodeId, "could not add", randomNumber, "to the log:", err)
 			}

--- a/raft/interface.go
+++ b/raft/interface.go
@@ -65,7 +65,7 @@ func StartRaft(lis *net.Listener, nodeDetails Node, pfsDirectory, raftInfoDirect
 }
 
 //A request to add a Log entry from a client. If the node is not the leader, it must forward the request to the leader.
-//Only returns once the request has been commited to the State machine
+//Only returns once the request has been committed to the State machine
 func (s *RaftNetworkServer) RequestAddLogEntry(entry *pb.Entry) (*StateMachineResult, error) {
 	s.addEntryLock.Lock()
 	defer s.addEntryLock.Unlock()

--- a/raft/raft.go
+++ b/raft/raft.go
@@ -459,7 +459,7 @@ func (s *RaftNetworkServer) manageElections() {
 		case _, ok := <-s.Quit:
 			if !ok {
 				s.QuitChannelClosed = true
-				Log.Info("Exiting elction managment loop")
+				Log.Info("Exiting election management loop")
 				return
 			}
 		case <-s.State.StartElection:
@@ -576,7 +576,7 @@ func (s *RaftNetworkServer) manageLeading() {
 			if !ok {
 				s.QuitChannelClosed = true
 				s.State.SetCurrentState(INACTIVE)
-				Log.Info("Exiting leading managment loop")
+				Log.Info("Exiting leading management loop")
 				return
 			}
 		case <-s.State.StartLeading:
@@ -631,7 +631,7 @@ func (s *RaftNetworkServer) manageConfigurationChanges() {
 		case _, ok := <-s.Quit:
 			if !ok {
 				s.QuitChannelClosed = true
-				Log.Info("Exiting configuration managment loop")
+				Log.Info("Exiting configuration management loop")
 				return
 			}
 		case config := <-s.State.ConfigurationApplied:
@@ -673,7 +673,7 @@ func (s *RaftNetworkServer) manageEntryApplication() {
 		case _, ok := <-s.Quit:
 			if !ok {
 				s.QuitChannelClosed = true
-				Log.Info("Exiting entry application managment loop")
+				Log.Info("Exiting entry application management loop")
 				return
 			}
 		case <-s.State.ApplyEntries:

--- a/raft/raftlog/raftlog_test.go
+++ b/raft/raftlog/raftlog_test.go
@@ -82,7 +82,7 @@ func TestWriteReadDelete(t *testing.T) {
 	}
 
 	if len(files) != 2 {
-		t.Error("number of files in directory is not what it shoudl be, writing error.")
+		t.Error("number of files in directory is not what it should be, writing error.")
 	}
 	if files[0].Name() != "1000001" || files[1].Name() != "1000002" {
 		t.Error("Files not named what they should be, file1: ", files[0].Name(), "file2: ", files[1].Name())

--- a/raft/raftstate.go
+++ b/raft/raftstate.go
@@ -282,7 +282,7 @@ func (s *RaftState) applyLogEntry(logEntry *pb.LogEntry) *StateMachineResult {
 	return nil
 }
 
-//ApplyLogEntries applys all log entries that have been commited but not yet applied
+//ApplyLogEntries applys all log entries that have been committed but not yet applied
 func (s *RaftState) ApplyLogEntries() {
 	s.stateChangeLock.Lock()
 	defer s.stateChangeLock.Unlock()

--- a/raft/snapshot.go
+++ b/raft/snapshot.go
@@ -297,27 +297,27 @@ func (s *RaftNetworkServer) applyLogUpdates(snapshotDirectory string, startIndex
 func performCleanup(snapshotPath string) error {
 	err := os.RemoveAll(path.Join(snapshotPath, "contents-tar"))
 	if err != nil {
-		return fmt.Errorf("error cleaning up temporay files: %s", err)
+		return fmt.Errorf("error cleaning up temporary files: %s", err)
 	}
 
 	err = os.RemoveAll(path.Join(snapshotPath, "inodes-tar"))
 	if err != nil {
-		return fmt.Errorf("error cleaning up temporay files: %s", err)
+		return fmt.Errorf("error cleaning up temporary files: %s", err)
 	}
 
 	err = os.RemoveAll(path.Join(snapshotPath, "names-tar"))
 	if err != nil {
-		return fmt.Errorf("error cleaning up temporay files: %s", err)
+		return fmt.Errorf("error cleaning up temporary files: %s", err)
 	}
 
 	err = os.RemoveAll(path.Join(snapshotPath, "meta"))
 	if err != nil {
-		return fmt.Errorf("error cleaning up temporay files: %s", err)
+		return fmt.Errorf("error cleaning up temporary files: %s", err)
 	}
 
 	err = os.Remove(path.Join(snapshotPath, PersistentConfigurationFileName))
 	if err != nil {
-		return fmt.Errorf("error cleaning up temporay files: %s", err)
+		return fmt.Errorf("error cleaning up temporary files: %s", err)
 	}
 	return nil
 }
@@ -470,19 +470,19 @@ func (s *RaftNetworkServer) InstallSnapshot(ctx context.Context, req *pb.Snapsho
 	if req.Offset == 0 {
 		err := os.RemoveAll(snapshotPath)
 		if err != nil {
-			Log.Error("Error recieving snapshot:", err)
+			Log.Error("Error receiving snapshot:", err)
 			return &pb.SnapshotResponse{s.State.GetCurrentTerm()}, err
 		}
 
 		err = os.Mkdir(snapshotPath, 0700)
 		if err != nil {
-			Log.Error("Error recieving snapshot:", err)
+			Log.Error("Error receiving snapshot:", err)
 			return &pb.SnapshotResponse{s.State.GetCurrentTerm()}, err
 		}
 
 		snapshotFile, err := os.Create(path.Join(snapshotPath, TarFileName))
 		if err != nil {
-			Log.Error("Error recieving snapshot:", err)
+			Log.Error("Error receiving snapshot:", err)
 			return &pb.SnapshotResponse{s.State.GetCurrentTerm()}, err
 		}
 		snapshotFile.Close()
@@ -490,18 +490,18 @@ func (s *RaftNetworkServer) InstallSnapshot(ctx context.Context, req *pb.Snapsho
 
 	snapshotFile, err := os.OpenFile(path.Join(snapshotPath, TarFileName), os.O_WRONLY, 0600)
 	if err != nil {
-		Log.Error("Error recieving snapshot:", err)
+		Log.Error("Error receiving snapshot:", err)
 		return &pb.SnapshotResponse{s.State.GetCurrentTerm()}, err
 	}
 	defer snapshotFile.Close()
 
 	bytesWritten, err := snapshotFile.WriteAt(req.Data, int64(req.Offset))
 	if err != nil {
-		Log.Error("Error recieving snapshot:", err)
+		Log.Error("Error receiving snapshot:", err)
 		return &pb.SnapshotResponse{s.State.GetCurrentTerm()}, err
 	}
 	if bytesWritten != len(req.Data) {
-		Log.Error("Error recieving snapshot: incorrect number of bytes written to snapshot file")
+		Log.Error("Error receiving snapshot: incorrect number of bytes written to snapshot file")
 		return &pb.SnapshotResponse{s.State.GetCurrentTerm()}, errors.New("incorrect number of bytes written to snapshot file")
 	}
 
@@ -586,7 +586,7 @@ func (s *RaftNetworkServer) sendSnapshot(node *Node) {
 					return
 				}
 				if done {
-					Log.Info("Sucessfully send complete snapshot to:", node.String())
+					Log.Info("Successfully send complete snapshot to:", node.String())
 					s.State.Configuration.SetNextIndex(node.NodeID, snapshotMeta.LastIncludedIndex+1)
 					return
 				}
@@ -677,7 +677,7 @@ func (s *RaftNetworkServer) manageSnapshoting() {
 		case _, ok := <-s.Quit:
 			if !ok {
 				s.QuitChannelClosed = true
-				Log.Info("Exiting snapshot managment loop")
+				Log.Info("Exiting snapshot management loop")
 				return
 			}
 		case <-snapshotTimer.C:

--- a/raft/test/snapshot_test.go
+++ b/raft/test/snapshot_test.go
@@ -78,7 +78,7 @@ func TestSnapshoting(t *testing.T) {
 		if err == nil {
 			break
 		}
-		//Sleep to give time for the snapshot managment goroutine to update the current snapshot
+		//Sleep to give time for the snapshot management goroutine to update the current snapshot
 		time.Sleep(1)
 	}
 
@@ -119,7 +119,7 @@ func TestSnapshoting(t *testing.T) {
 		if err == nil {
 			break
 		}
-		//Sleep to give time for the snapshot managment goroutine to update the current snapshot
+		//Sleep to give time for the snapshot management goroutine to update the current snapshot
 		time.Sleep(1)
 	}
 


### PR DESCRIPTION
Please ignore moves of imports. They were automatically moved when saving. Proper fix is in #33 