### PR TITLE
discovery-server: Removed the unnecessary port check

### DIFF
--- a/discovery-server/main.go
+++ b/discovery-server/main.go
@@ -70,17 +70,13 @@ func main() {
 
 	dnetserver.RenewInterval = renewDuration
 
-	if *port < 1 || *port > 65535 || *fileServerPort < 1 || *fileServerPort > 65535 {
-		dnetserver.Log.Fatal("Ports must be a number between 1 and 65535, inclusive.")
-	}
-
 	dnetserver.Log.Info("Starting Paranoid Discovery Server")
 
 	lis, err := net.Listen("tcp", ":"+strconv.Itoa(*port))
 	if err != nil {
 		dnetserver.Log.Fatalf("Failed to listen on port %d: %v.", *port, err)
 	}
-	dnetserver.Log.Info("Listening on port", *port)
+	dnetserver.Log.Infof("Listening on %s", lis.Addr().String())
 
 	if *loadState {
 		dnetserver.LoadState()


### PR DESCRIPTION
The port check was unnecessary as `net.Listen` would fail if the port is too high. The implementation also did not allow for port `0` which is a valid port.

Completes #62 